### PR TITLE
MPN 990

### DIFF
--- a/project/CompilerSettings.scala
+++ b/project/CompilerSettings.scala
@@ -6,7 +6,6 @@ object CompilerSettings {
 			scalacOptions ++= Seq(
 			"-deprecation",
 			"-explaintypes",
-			"-target:jvm-1.8",
 		  "-encoding", "UTF-8",
 		  "-feature",
 		  "-language:higherKinds",

--- a/project/Project.scala
+++ b/project/Project.scala
@@ -40,7 +40,7 @@ object TTFIBuild extends Build {
       publishMavenStyle := true,
       organization := ORG_NAME,
       version := "0.1-SNAPSHOT",
-      scalaVersion := "2.11.5"
+      scalaVersion := "2.11.6"
     )
 
   def defaultProject: Project => Project = _.

--- a/ttfi-core/src/main/scala/finals/Flattening.scala
+++ b/ttfi-core/src/main/scala/finals/Flattening.scala
@@ -1,0 +1,42 @@
+package finals
+
+object Flattening {
+  // make the context on which the operation depends explicit
+  sealed trait LCACtx[+repr[_]]
+  case object NonLCA extends LCACtx[Nothing]
+  case class LCA[+repr[_]](e: repr[Integer]) extends LCACtx[repr]
+
+  // instance ExpSYM repr ⇒ ExpSYM (LCACtx → repr) where
+  // instance ExpSYM repr ⇒ ExpSYM (LCACtx repr → repr) where
+
+  // [[http://stackoverflow.com/a/8736360][typed lambdas]]
+  // this trait allows us to provide nicer type signatures. without this,
+  // instead of LCACtx_=>[repr]#τ we'd be using something like the following
+  // ({ type λ[T] = LCACtx => repr[T] })#λ
+  // alternatively, use <https://github.com/non/kind-projector>
+  trait LCACtx_=>[repr[_]] {
+    type τ[T] = LCACtx[repr] => repr[T]
+  }
+
+  def apply[repr[_]](e: LCACtx[repr] => repr[Integer]): repr[Integer] = e(NonLCA: LCACtx[repr])
+
+  import ExpSym._
+  // what we'd like is something like the following:
+  // implicit object ExpSym_LCACtx[repr](implicit s1: ExpSym[repr]) extends ExpSym[LCACtx_=>[repr]#τ]
+  //
+  // due to limitation that scala objects need to have a concrete type, this
+  // needs to be an 'implicit class'. _x is needed due to the requirement that
+  // implicit classes have one argument
+  implicit class ExpSym_Flat_LCACtx[repr[_]](_x: Any = null)(implicit e: ExpSym[repr]) extends ExpSym[LCACtx_=>[repr]#τ] {
+    import e._
+    def lit = (x: Integer) => (ctx: LCACtx[repr]) => ctx match {
+      case NonLCA => e.lit(x)
+      case LCA(v) => e.add(e.lit(x))(v)
+    }
+    def neg = x => (ctx: LCACtx[repr]) => ctx match {
+      case NonLCA => e.neg(x(NonLCA))
+      case LCA(v) => e.add(e.neg(x(NonLCA)))(v)
+    }
+    def add = x => y => (ctx: LCACtx[repr]) => x(LCA(y(ctx)))
+  }
+}

--- a/ttfi-core/src/main/scala/initial/FP.scala
+++ b/ttfi-core/src/main/scala/initial/FP.scala
@@ -13,13 +13,14 @@ object FP {
     case Neg(x) => -eval(x)
     case Add(x, y) => eval(x) + eval(y)
   }
+
   def view[A](x: Exp[A]): String = x match {
     case Lit(x) => x.toString
     case Neg(x) => s"(-${view(x)})"
     case Add(x, y) => s"(${view(x)} + ${view(y)})"
   }
 
-  val tf1 = Add(Lit(8), Neg(Add(Lit(1), Lit(2))))
+  val ti1 = Add(Lit(8), Neg(Add(Lit(1), Lit(2))))
 
   // pushNeg
   def pushNeg(x: Exp[Integer]): Exp[Integer] = x match {
@@ -33,5 +34,22 @@ object FP {
     case Neg(Add(e1, e2)) => Add(pushNeg(Neg(e1)), pushNeg(Neg(e2)))
     case Add(e1, e2) => Add(pushNeg(e1), pushNeg(e2))
   }
-  val result = view(pushNeg(tf1))
+
+  val ti1Norm = pushNeg(ti1)
+  val ti1NormView = view(ti1Norm)
+  val ti1NormEval = eval(ti1Norm)
+
+  // flata
+  def flata(x: Exp[Integer]): Exp[Integer] = x match {
+    case e @ Lit(_) => e
+    case e @ Neg(_) => e
+    case Add(Add(e1, e2), e3) => flata(Add(e1, Add(e2, e3)))
+    case Add(e1, e2) => Add(e1, flata(e2))
+  }
+
+  val norm = flata _ compose pushNeg _
+  val ti3 = Add(ti1, Neg(Neg(ti1)))
+  val ti3View = view(ti3)
+  val ti3Norm = norm(ti3)
+  val ti3NormView = view(ti3Norm)
 }

--- a/ttfi-core/src/test/scala/finals/FlatteningSpecs.scala
+++ b/ttfi-core/src/test/scala/finals/FlatteningSpecs.scala
@@ -1,0 +1,47 @@
+package finals
+
+import org.specs2.Specification
+
+class FlatteningSpecs extends Specification {
+  def is = s2"""
+  ti3 view $e1
+  ti3 push neg view $e2
+  ti3 flattening view $e3
+  ti3 normalized view $e4
+"""
+
+  import Exp.view
+  import ExpSym.ExpSym
+  import ExpSym.ExpSym_Debug
+
+  def tf1[repr[_]](implicit s: ExpSym[repr]): repr[Integer] = {
+    import s._
+    add(
+      lit(8))(
+        neg(
+          add(
+            lit(1))(
+              lit(2))))
+  }
+
+  def tf3[repr[_]](implicit s: ExpSym[repr]): repr[Integer] = {
+    import s._
+    add(tf1(s))(neg(neg(tf1(s))))
+  }
+
+  import PushNeg._
+  import Flattening._
+
+  type PushNegCtx[T] = PushNeg.Ctx_=>[Exp.Debug]#τ[T]
+  type FlatCtx[T] = Flattening.LCACtx_=>[Exp.Debug]#τ[T]
+
+  val tf3View = view(tf3)
+
+  val tf3PushNegView = view(PushNeg(tf3[Ctx_=>[Exp.Debug]#τ]({})))
+  val tf3FlatteningView = view(Flattening(tf3[LCACtx_=>[Exp.Debug]#τ]({})))
+
+  def e1 = tf3View === "((8 + (-(1 + 2))) + (-(-(8 + (-(1 + 2))))))"
+  def e2 = tf3PushNegView === "((8 + ((-1) + (-2))) + (8 + ((-1) + (-2))))"
+  def e3 = tf3FlatteningView === "(8 + ((-(1 + 2)) + (-(-(8 + (-(1 + 2)))))))"
+  def e4 = pending // tf3NormView === "(8 + ((-1) + ((-2) + (8 + ((-1) + (-2))))))"
+}

--- a/ttfi-core/src/test/scala/finals/SimplyTypedLambdaCalculusSpecs.scala
+++ b/ttfi-core/src/test/scala/finals/SimplyTypedLambdaCalculusSpecs.scala
@@ -30,7 +30,7 @@ class SimplyTypedLambdaCalculusSpecs extends Specification {
 
   def eval_ = {
     eval(th1[Eval]) ==== 3 &&
-      eval(th4[Eval]) ==== 2
+      eval(th4[Eval])(_ - 1) ==== 2
   }
 
   def show_ = {

--- a/ttfi-core/src/test/scala/initial/FPSpecs.scala
+++ b/ttfi-core/src/test/scala/initial/FPSpecs.scala
@@ -1,1 +1,37 @@
 package initial
+
+import org.specs2._
+
+class FPSpecs extends Specification {
+  def is = s2"""
+  pushNeg
+    ti1 normalized expression $e1
+    ti1 normalized view $e2
+    ti1 normalized eval $e3
+
+  norm = flata o pushNeg
+    ti3 view $e4
+    ti3 push neg view $e5
+    ti3 flata view $e6
+    ti3 normalized $e7
+    ti3 normalized view $e8
+"""
+
+  import FP._
+
+  def e1 = ti1Norm === Add(Lit(8), Add(Neg(Lit(1)), Neg(Lit(2))))
+  def e2 = ti1NormView === "(8 + ((-1) + (-2)))"
+  def e3 = ti1NormEval mustEqual 5
+
+  def e4 = ti3View === "((8 + (-(1 + 2))) + (-(-(8 + (-(1 + 2))))))"
+  def e5 = view(pushNeg(ti3)) === "((8 + ((-1) + (-2))) + (8 + ((-1) + (-2))))"
+  def e6 = view(flata(ti3)) === "(8 + ((-(1 + 2)) + (-(-(8 + (-(1 + 2)))))))"
+  def e7 = ti3Norm ===
+    Add(Lit(8),
+      Add(Neg(Lit(1)),
+        Add(Neg(Lit(2)),
+          Add(Lit(8),
+            Add(Neg(Lit(1)),
+              Neg(Lit(2)))))))
+  def e8 = ti3NormView === "(8 + ((-1) + ((-2) + (8 + ((-1) + (-2))))))"
+}


### PR DESCRIPTION
Fixes compilation with JDKv7, bumps scala version and adds initial implementation for normalization.

36e391a MPN-990: Partially implement normalization
7a1c5d3 MPN-990: Implement flata and norm for the initial view
1ce7c73 MPN-990: Bump Scala version to 2.11.6
e5ccedb MPN-990: Fix test compilation error due to missing argument
3b57916 MPN-990: Remove -target:jvm-1.8 from scalacOptions
